### PR TITLE
docs(credits): 更新 Simplified Chinese 译者署名

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -11,7 +11,7 @@ Thank you to all translators on the discord that have helped with this project!
 
 &aLetsGoAway&r - English (en_UK, en_US)
 &aVincent Wang (vincentx0905)&r - Traditional Chinese (zh_TW)
-&aning_mo&r - Simplified Chinese (zh_CN)
+&a柠枺(NingMo)&r - Simplified Chinese (zh_CN)
 &aClumsius Pavillion (clumsius)&r - French (fr_FR)
 &aLa Piedra (lapiedraomg)&r - Spanish (es_ES, es_MX)
 &aariiiiiq&r - Indonesian (id_ID)


### PR DESCRIPTION
CN: 将 Simplified Chinese 译者 ning_mo 的署名更新为 "柠枺(NingMo)"，以反映译者的正确昵称。
EN: Updated the Chinese Simplified translator's ning_mo's byline to "柠枺(NingMo)" to reflect the translator's correct nickname

CN: 可以拒绝此次请求，我不介意。
EN: You can refuse this request, I don't mind